### PR TITLE
make sure that hist is not None

### DIFF
--- a/pyhstr/application.py
+++ b/pyhstr/application.py
@@ -88,7 +88,9 @@ class App:
                 for cmd_idx in reversed(cmd_indexes):
                     readline.remove_history_item(cmd_idx)
 
-                readline.write_history_file(str(SHELLS[SHELL]["hist"]))
+                history_path = SHELLS[SHELL]["hist"]
+                assert history_path is not None
+                readline.write_history_file(str(history_path))
 
             elif SHELL == Shell.IPYTHON:
                 import IPython


### PR DESCRIPTION
Fixes #11 

Before this PR, if `SHELLS[SHELL]["hist"]` is None (it should never be), then pyhstr silently writes the history to a file named `None`, and a bug like that might go unnoticed for a long time. This PR changes it to instead fail with an assertion error.

The `str()` is still needed to convert a `pathlib.Path` to a string.