### PR TITLE
build on pull-request

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,6 @@
 name: pyhstr
 
-on: [push]
+on: [push, pull-request]
 
 jobs:
   build:


### PR DESCRIPTION
#21 got reverted because pylint failed after merging it. This PR should make `tox` run when a pull request is created.

I don't know if this is going to actually work because a pull request must be created to test this.